### PR TITLE
PMG-392 Map Design - clicking on a plugin should not add it to the map

### DIFF
--- a/console/src/app/maps/map-detail/map-edit/map-design/map-design.component.ts
+++ b/console/src/app/maps/map-detail/map-edit/map-design/map-design.component.ts
@@ -274,8 +274,8 @@ export class MapDesignComponent implements OnInit, AfterContentInit, OnDestroy {
         y: obj.y - (240 * this.scale)
       },
       size: {
-        width: 110,
-        height: 75
+        width: 100,
+        height: 73
       },
       inPorts: [' '],
       outPorts: ['  '],


### PR DESCRIPTION
Set node size on map design to be equal to node on plugin toolbox